### PR TITLE
Refs #1145: Keyboard Interaction Model

### DIFF
--- a/app/assets/javascripts/backbone/views/calendars/calendar_view.js
+++ b/app/assets/javascripts/backbone/views/calendars/calendar_view.js
@@ -21,6 +21,8 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
     this.timedEventsOnly = options.timedEventsOnly;
     this.allDayText = options.allDayText;
     this._fcHeaderLastFocusKey = null;
+    this._fcGridFocusDate = null;
+    this._fcGridShouldFocus = false;
     this.showAppropriateEarlyLink();
     this.initCalendar();
   },
@@ -35,6 +37,10 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
     return {
       "click .modal .btn-primary": "create",
       "click .early": "showHideEarly",
+      "click .fc-day[data-date]": "onGridCellClick",
+      "focusin .fc-day[data-date]": "onGridCellFocusIn",
+      "focusin .fc-view": "onGridViewFocusIn",
+      "keydown .fc-day[data-date]": "onGridCellKeydown",
 
       /*
        * Capture header interactions before FullCalendar handles them, so we can restore focus
@@ -147,9 +153,7 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
       if (start.hasTime()) {
         startTime = start.format(Gather.TIME_FORMATS.regTime);
         endTime = end.format(Gather.TIME_FORMATS.regTime);
-        body.html(
-          `Create event on <b>${date}</b> from <b>${startTime}</b> to <b>${endTime}</b>?`
-        );
+        body.html(`Create event on <b>${date}</b> from <b>${startTime}</b> to <b>${endTime}</b>?`);
       } else {
         body.html(`Create event on <b>${date}</b>?`);
       }
@@ -219,6 +223,12 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
       return;
     }
 
+    /*
+     * FullCalendar uses nested layout tables; mark wrappers presentational
+     * so screen readers announce the grid model instead of table boundaries.
+     */
+    this.calendar.find(".fc-view > table").attr("role", "presentation");
+
     if (view.name === "month") {
       const $grid = this.calendar.find(".fc-month-view").first();
       if (!$grid.length) {
@@ -227,6 +237,8 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
       $grid.attr("role", "grid");
       $grid.find(".fc-row").attr("role", "row");
       $grid.find(".fc-day").attr("role", "gridcell");
+      $grid.find(".fc-row table").attr("role", "presentation");
+      this.applyFullCalendarGridKeyboard();
       return;
     }
 
@@ -236,6 +248,8 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
         $allDayGrid.attr("role", "grid");
         $allDayGrid.find(".fc-row").attr("role", "row");
         $allDayGrid.find(".fc-day").attr("role", "gridcell");
+        $allDayGrid.find(".fc-row table").attr("role", "presentation");
+        this.applyFullCalendarGridKeyboard();
       }
 
       const $timeGrid = this.calendar.find(".fc-time-grid").first();
@@ -243,8 +257,145 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
         $timeGrid.attr("role", "grid");
         $timeGrid.find(".fc-slats tr").attr("role", "row");
         $timeGrid.find(".fc-slats td").attr("role", "gridcell");
+        $timeGrid.find("table").attr("role", "presentation");
       }
     }
+  },
+
+  applyFullCalendarGridKeyboard() {
+    const view = this.calendar.fullCalendar("getView");
+    if (!view) {
+      return;
+    }
+
+    this.calendar.find(".fc-view").attr("tabindex", "0");
+    const today = $.fullCalendar.moment();
+    let focusDate = this._fcGridFocusDate;
+
+    if (!focusDate) {
+      if (this.getGridDayCell(today).length) {
+        focusDate = today.format("YYYY-MM-DD");
+      } else {
+        focusDate = view.intervalStart.format("YYYY-MM-DD");
+      }
+    }
+
+    this.setGridFocus(focusDate, {focus: this._fcGridShouldFocus});
+    this._fcGridShouldFocus = false;
+  },
+
+  onGridCellClick(e) {
+    const date = this.gridDateFromCell($(e.currentTarget));
+    if (!date) {
+      return;
+    }
+    this.setGridFocus(date, {focus: false});
+  },
+
+  onGridCellFocusIn(e) {
+    const date = this.gridDateFromCell($(e.currentTarget));
+    if (!date) {
+      return;
+    }
+    this.setGridFocus(date, {focus: false});
+  },
+
+  onGridViewFocusIn(e) {
+    if (!$(e.target).is(".fc-view")) {
+      return;
+    }
+    this.applyFullCalendarGridKeyboard();
+    if (this._fcGridFocusDate) {
+      this.setGridFocus(this._fcGridFocusDate, {focus: true});
+    }
+  },
+
+  onGridCellKeydown(e) {
+    const keyCode = e.which || e.keyCode;
+    const date = this.gridDateFromCell($(e.currentTarget));
+    if (!date) {
+      return;
+    }
+
+    let nextDate = null;
+    if (keyCode === 37) {
+      nextDate = date.clone().add(-1, "day");
+    } else if (keyCode === 39) {
+      nextDate = date.clone().add(1, "day");
+    } else if (keyCode === 38) {
+      nextDate = date.clone().add(-1, "week");
+    } else if (keyCode === 40) {
+      nextDate = date.clone().add(1, "week");
+    } else if (keyCode === 36) {
+      nextDate = date.clone().startOf("week");
+    } else if (keyCode === 35) {
+      nextDate = date.clone().endOf("week").startOf("day");
+    } else if (keyCode === 33) {
+      nextDate = date.clone().add(-1, "month");
+    } else if (keyCode === 34) {
+      nextDate = date.clone().add(1, "month");
+    } else if (keyCode === 13 || keyCode === 32) {
+      this.selectDateFromGrid(date);
+      e.preventDefault();
+      return;
+    } else {
+      return;
+    }
+
+    this.moveGridFocusToDate(nextDate);
+    e.preventDefault();
+  },
+
+  selectDateFromGrid(date) {
+    if (!this.canCreate) {
+      return;
+    }
+    const start = date.clone().startOf("day");
+    const end = date.clone().add(1, "day").startOf("day");
+    this.calendar.fullCalendar("select", start, end);
+  },
+
+  moveGridFocusToDate(date) {
+    const dateString = date.format("YYYY-MM-DD");
+    this._fcGridFocusDate = dateString;
+
+    if (this.getGridDayCell(date).length) {
+      this.setGridFocus(dateString, {focus: true});
+      return;
+    }
+
+    this._fcGridShouldFocus = true;
+    this.calendar.fullCalendar("gotoDate", date);
+  },
+
+  setGridFocus(date, options) {
+    const dateString = typeof date === "string" ? date : date.format("YYYY-MM-DD");
+    const $cells = this.calendar.find(".fc-day[data-date]");
+    const $target = this.getGridDayCell(dateString);
+    if (!$target.length) {
+      return false;
+    }
+
+    $cells.attr("tabindex", "-1");
+    $target.attr("tabindex", "0");
+    if (options && options.focus) {
+      $target.focus();
+    }
+    this._fcGridFocusDate = dateString;
+    return true;
+  },
+
+  getGridDayCell(date) {
+    const dateString = typeof date === "string" ? date : date.format("YYYY-MM-DD");
+    return this.calendar.find(`.fc-day[data-date="${dateString}"]`).first();
+  },
+
+  gridDateFromCell($cell) {
+    const dateString = $cell.data("date") || $cell.attr("data-date");
+    if (!dateString) {
+      return null;
+    }
+    return $.fullCalendar.moment(dateString, "YYYY-MM-DD");
   },
 
   onLoading(isLoading) {

--- a/app/assets/stylesheets/global/fullcalendar_overrides.scss
+++ b/app/assets/stylesheets/global/fullcalendar_overrides.scss
@@ -29,4 +29,9 @@
   .fc-month-view .fc-day-grid .fc-row {
     min-height: 90px;
   }
+
+  .fc-day[tabindex="0"]:focus {
+    outline: 2px solid $theme-main;
+    outline-offset: -2px;
+  }
 }


### PR DESCRIPTION
- Improve calendar grid keyboard navigation and focus accessibility
- Implement a consistent keyboard model for date cells (arrow keys, Home/End, PageUp/PageDown, Enter/Space), keep Tab as an escape path, and add visible focus styling. Also apply ARIA role updates to reduce table-structure announcements and improve screen reader behavior in FullCalendar’s nested layouts.

TESTS PERFORMED

Arrow key navigation in grid
- Left/Right moves focus one day backward/forward.
- Up/Down moves focus one week backward/forward.
Home/End behavior
- Home moves focus to start of current week.
- End moves focus to end of current week.

PageUp/PageDown behavior
- PageUp moves focus to same day in previous month.
- PageDown moves focus to same day in next month.
- If target day is outside current view, calendar navigates and focus restores to target date.

Selection keys
- Enter on focused date selects date.
- Space on focused date selects date.

Tab escape (no keyboard trap)
- Tabbing into calendar works.
- Tabbing from focused date exits grid normally to next focusable element.

Visible focus indicator
- Focused day cell shows clear visual outline.
Screen reader/table semantics checks
-Verified table announcements during navigation and adjusted roles to reduce unnecessary table boundary announcements.
-Added presentational roles on layout tables so navigation is announced more like a grid.

Unable to Test
Selection behavior respects create permissions (only selects when creation is allowed).