### PR TITLE
Add live region for calendar month changes announcement (#1148)

### DIFF
--- a/app/assets/javascripts/backbone/views/calendars/calendar_view.js
+++ b/app/assets/javascripts/backbone/views/calendars/calendar_view.js
@@ -15,6 +15,7 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
     this.viewParams = options.viewParams;
     this.defaultViewType = options.defaultViewType || "week";
     this.calendar = this.$("#calendar");
+    this.liveRegion = this.$("#calendar-live-region");
     this.ruleSet = options.ruleSet;
     this.canCreate = options.canCreate;
     this.calendarId = options.calendarId;
@@ -23,6 +24,7 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
     this._fcHeaderLastFocusKey = null;
     this._fcGridFocusDate = null;
     this._fcGridShouldFocus = false;
+    this._calendarLiveRegionText = null;
     this.showAppropriateEarlyLink();
     this.initCalendar();
   },
@@ -79,6 +81,7 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
       loading: this.onLoading.bind(this),
       eventDrop: this.onEventChange.bind(this),
       eventResize: this.onEventChange.bind(this),
+      viewRender: this.updateCalendarLiveRegion.bind(this),
       eventAfterAllRender: this.onViewRender.bind(this),
     });
   },
@@ -175,7 +178,27 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
   onViewRender() {
     this.applyFullCalendarHeaderA11y();
     this.applyFullCalendarGridA11y();
+    this.updateCalendarLiveRegion();
     this.$el.trigger("viewRender"); // Notify other views
+  },
+
+  updateCalendarLiveRegion() {
+    const view = this.calendar.fullCalendar("getView");
+    if (!this.liveRegion.length) {
+      return;
+    }
+
+    if (!view || view.name !== "month") {
+      this.liveRegion.text("");
+      this._calendarLiveRegionText = null;
+      return;
+    }
+
+    const message = `Calendar now showing ${view.intervalStart.format("MMMM YYYY")}`;
+    if (message !== this._calendarLiveRegionText) {
+      this.liveRegion.text(message);
+      this._calendarLiveRegionText = message;
+    }
   },
 
   captureHeaderControlActivation(e) {

--- a/app/views/calendars/events/index.html.erb
+++ b/app/views/calendars/events/index.html.erb
@@ -19,6 +19,7 @@
 
 <div id="calendar-and-sidebar">
   <div id="calendar-col">
+    <div id="calendar-live-region" class="sr-only" aria-live="polite" aria-atomic="true"></div>
     <div id="calendar"></div>
     <footer>
       <%= link_to("Permalink", @permalink, id: "permalink") %> &nbsp;

--- a/spec/system/calendars/events/index_spec.rb
+++ b/spec/system/calendars/events/index_spec.rb
@@ -284,6 +284,24 @@ describe "event calendar", js: true do
   describe "calendar grid accessibility states" do
     let(:calendar) { create(:calendar) }
 
+    scenario "announces month changes in a live region" do
+      visit(calendar_events_path(calendar))
+      find(".fc-month-button").click
+
+      expect(page).to have_css(
+        "#calendar-live-region[aria-live='polite'][aria-atomic='true']",
+        visible: false
+      )
+
+      next_month = Time.zone.today.next_month.strftime("%B %Y")
+      find(".fc-next-button").click
+      expect(page).to have_css(
+        "#calendar-live-region",
+        text: "Calendar now showing #{next_month}",
+        visible: false
+      )
+    end
+
     scenario "exposes selected, active, and today states on date cells" do
       visit(calendar_events_path(calendar))
       find(".fc-month-button").click


### PR DESCRIPTION
Closes #1148

Announces the visible month and year when users switch to Month view or navigate between months.

Tests:
- Manually verified with a screen reader that months are announced when switching views and changing months.
- Ran `bundle exec rspec spec/system/calendars/events/index_spec.rb`.
- Ran `RAILS_ENV=development bundle exec rails runner "puts 'ok'"`.
- Ran `bundle exec rubocop spec/system/calendars/events/index_spec.rb`.