### PR TITLE
1150-announce-no-events-calendar

### DIFF
--- a/app/assets/javascripts/backbone/views/calendars/calendar_view.js
+++ b/app/assets/javascripts/backbone/views/calendars/calendar_view.js
@@ -693,9 +693,13 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
     const eventKey = this.eventCountKey(event);
     const start = event.start.clone();
     const end = this.eventEnd(event);
+    const visibleRange = this.visibleDateRange();
+    if (!visibleRange) {
+      return;
+    }
+
     this._renderedEventRangesByKey[eventKey] = {start, end};
 
-    const visibleRange = this.visibleDateRange();
     let date = (start.isAfter(visibleRange.start) ? start : visibleRange.start)
       .clone()
       .startOf("day");
@@ -718,9 +722,16 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
 
   visibleDateRange() {
     const view = this.calendar.fullCalendar("getView");
+    const start = view && (view.start || view.intervalStart);
+    const end = view && (view.end || view.intervalEnd);
+
+    if (!start || !end) {
+      return null;
+    }
+
     return {
-      start: (view && (view.start || view.intervalStart)).clone(),
-      end: (view && (view.end || view.intervalEnd)).clone(),
+      start: start.clone(),
+      end: end.clone(),
     };
   },
 

--- a/app/assets/javascripts/backbone/views/calendars/calendar_view.js
+++ b/app/assets/javascripts/backbone/views/calendars/calendar_view.js
@@ -25,6 +25,8 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
     this._fcGridFocusDate = null;
     this._fcGridShouldFocus = false;
     this._calendarLiveRegionText = null;
+    this._renderedEventDateKeys = {};
+    this._renderedEventRangesByKey = {};
     this.showAppropriateEarlyLink();
     this.initCalendar();
   },
@@ -80,7 +82,11 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
       loading: this.onLoading.bind(this),
       eventDrop: this.onEventChange.bind(this),
       eventResize: this.onEventChange.bind(this),
-      viewRender: this.updateCalendarLiveRegion.bind(this),
+      viewRender: () => {
+        this.resetRenderedEventCounts();
+        this.updateCalendarLiveRegion({includeEmptyState: false});
+      },
+      eventAfterRender: this.trackRenderedEventCount.bind(this),
       eventAfterAllRender: this.onViewRender.bind(this),
     });
   },
@@ -181,22 +187,47 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
     this.$el.trigger("viewRender"); // Notify other views
   },
 
-  updateCalendarLiveRegion() {
+  updateCalendarLiveRegion(options) {
     const view = this.calendar.fullCalendar("getView");
     if (!this.liveRegion.length) {
       return;
     }
 
-    if (!view || view.name !== "month") {
+    if (!view) {
       this.liveRegion.text("");
       this._calendarLiveRegionText = null;
       return;
     }
 
-    const message = `Calendar now showing ${view.intervalStart.format("MMMM YYYY")}`;
+    const message = this.calendarLiveRegionMessage(view, options || {});
     if (message !== this._calendarLiveRegionText) {
       this.liveRegion.text(message);
       this._calendarLiveRegionText = message;
+    }
+  },
+
+  calendarLiveRegionMessage(view, options) {
+    const messageParts = [];
+    if (view.name === "month") {
+      messageParts.push(`Calendar now showing ${view.intervalStart.format("MMMM YYYY")}`);
+    }
+
+    if (
+      options.includeEmptyState !== false &&
+      (view.name === "agendaWeek" || view.name === "month")
+    ) {
+      const eventCount = this.renderedEventCountInInterval(view.intervalStart, view.intervalEnd);
+      messageParts.push(`${this.eventCountLabel(eventCount)} ${this.eventCountPeriodForView(view)}`);
+    }
+
+    return messageParts.join(". ");
+  },
+
+  eventCountPeriodForView(view) {
+    if (view.name === "agendaWeek") {
+      return "this week";
+    } else {
+      return "this month";
     }
   },
 
@@ -307,13 +338,20 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
   },
 
   applyFullCalendarGridDateLabels() {
+    const view = this.calendar.fullCalendar("getView");
     this.calendar.find(".fc-bg .fc-day[data-date]:visible").each((_, cell) => {
       const $cell = $(cell);
       const dateString = $cell.attr("data-date");
       const date = $.fullCalendar.moment(dateString, "YYYY-MM-DD");
 
       if (date.isValid()) {
-        $cell.attr("aria-label", date.format("dddd, MMMM D, YYYY"));
+        const showCount =
+          view && (view.name === "month" || view.name === "agendaDay" || view.name === "agendaWeek");
+        let label = date.format("dddd, MMMM D, YYYY");
+        if (showCount) {
+          label += `, ${this.eventCountLabel(this.renderedEventCountOnDay(date))}`;
+        }
+        $cell.attr("aria-label", label);
       }
     });
   },
@@ -522,10 +560,10 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
     }
 
     if (view.name === "month") {
-      return this.calendar.find(".fc-month-view .fc-day[data-date]:visible");
+      return this.calendar.find(".fc-month-view .fc-bg .fc-day[data-date]:visible");
     }
 
-    const $allDayCells = this.calendar.find(".fc-agenda-view .fc-day-grid .fc-day[data-date]:visible");
+    const $allDayCells = this.calendar.find(".fc-agenda-view .fc-day-grid .fc-bg .fc-day[data-date]:visible");
     if ($allDayCells.length) {
       return $allDayCells;
     }
@@ -631,12 +669,78 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
     this.calendar.fullCalendar("changeView", viewType, date);
   },
 
-  hasEventInInterval(start, end) {
-    const matches = this.calendar.fullCalendar(
-      "clientEvents",
-      (event) => event.start.isBefore(end) && event.end.isAfter(start)
-    );
-    return matches.length > 0;
+  resetRenderedEventCounts() {
+    this._renderedEventDateKeys = {};
+    this._renderedEventRangesByKey = {};
+  },
+
+  eventCountLabel(eventCount) {
+    if (eventCount === 0) {
+      return "No events";
+    } else if (eventCount === 1) {
+      return "1 event";
+    } else {
+      return `${eventCount} events`;
+    }
+  },
+
+  trackRenderedEventCount(event, el) {
+    const $el = $(el);
+    if ($el.hasClass("fc-bg-event")) {
+      return;
+    }
+
+    const eventKey = this.eventCountKey(event);
+    const start = event.start.clone();
+    const end = this.eventEnd(event);
+    this._renderedEventRangesByKey[eventKey] = {start, end};
+
+    const visibleRange = this.visibleDateRange();
+    let date = (start.isAfter(visibleRange.start) ? start : visibleRange.start)
+      .clone()
+      .startOf("day");
+    const lastDate = (end.isBefore(visibleRange.end) ? end : visibleRange.end)
+      .clone()
+      .subtract(1, "second")
+      .startOf("day");
+    while (!date.isAfter(lastDate, "day")) {
+      const dateString = date.format("YYYY-MM-DD");
+      this._renderedEventDateKeys[dateString] = this._renderedEventDateKeys[dateString] || {};
+      this._renderedEventDateKeys[dateString][eventKey] = true;
+      date.add(1, "day");
+    }
+  },
+
+  eventCountKey(event) {
+    const id = event.id || event.eventId || event._id || event.title;
+    return `${id}-${event.start.format()}-${this.eventEnd(event).format()}`;
+  },
+
+  visibleDateRange() {
+    const view = this.calendar.fullCalendar("getView");
+    return {
+      start: (view && (view.start || view.intervalStart)).clone(),
+      end: (view && (view.end || view.intervalEnd)).clone(),
+    };
+  },
+
+  eventEnd(event) {
+    if (event.end) {
+      return event.end;
+    }
+
+    return event.start.clone().add(1, event.allDay ? "day" : "second");
+  },
+
+  renderedEventCountInInterval(start, end) {
+    return Object.values(this._renderedEventRangesByKey)
+      .filter((range) => range.start.isBefore(end) && range.end.isAfter(start))
+      .length;
+  },
+
+  renderedEventCountOnDay(date) {
+    const dateString = date.format("YYYY-MM-DD");
+    return Object.keys(this._renderedEventDateKeys[dateString] || {}).length;
   },
 
   applyFixedTimes(start, end) {

--- a/spec/system/calendars/events/index_spec.rb
+++ b/spec/system/calendars/events/index_spec.rb
@@ -313,26 +313,64 @@ describe "event calendar", js: true do
       )
     end
 
+    scenario "announces empty week and month views in a live region" do
+      visit(calendar_events_path(calendar))
+
+      expect(page).to have_css("#calendar-live-region", text: "No events this week", visible: false)
+
+      find(".fc-agendaDay-button").click
+      expect(page).to have_css("#calendar-live-region", text: "", visible: false)
+
+      find(".fc-month-button").click
+      expect(page).to have_css("#calendar-live-region", text: "No events this month", visible: false)
+    end
+
+    scenario "announces event counts for views and focused day cells" do
+      today = Time.zone.today
+      create(:event, calendar: calendar, all_day: true, starts_at: today.in_time_zone,
+        ends_at: today.in_time_zone + 1.day - 1.second)
+
+      visit(calendar_events_path(calendar))
+
+      today_label = page.evaluate_script(
+        "`${moment('#{today.to_fs(:no_time)}', 'YYYY-MM-DD').format('dddd, MMMM D, YYYY')}, 1 event`"
+      )
+
+      expect(page).to have_css("#calendar-live-region", text: "1 event this week", visible: false)
+      expect(page).to have_css(
+        ".fc-agendaWeek-view .fc-day-grid .fc-bg .fc-day[data-date='#{today.to_fs(:no_time)}']" \
+        "[aria-label='#{today_label}']"
+      )
+
+      find(".fc-month-button").click
+      expect(page).to have_css("#calendar-live-region", text: "1 event this month", visible: false)
+      expect(page).to have_css(
+        ".fc-month-view .fc-bg .fc-day[data-date='#{today.to_fs(:no_time)}'][aria-label='#{today_label}']"
+      )
+    end
+
     scenario "exposes selected, active, and today states on date cells" do
       visit(calendar_events_path(calendar))
       find(".fc-month-button").click
 
       today = Time.zone.today
       today_date = today.to_fs(:no_time)
-      today_label = page.evaluate_script("moment('#{today_date}', 'YYYY-MM-DD').format('dddd, MMMM D, YYYY')")
+      today_label = page.evaluate_script(
+        "`${moment('#{today_date}', 'YYYY-MM-DD').format('dddd, MMMM D, YYYY')}, No events`"
+      )
       selected_cell_selector =
-        ".fc-month-view .fc-day[data-date][tabindex='0'][aria-selected='true']"
+        ".fc-month-view .fc-bg .fc-day[data-date][tabindex='0'][aria-selected='true']"
 
       expect(page).to have_css(".fc-month-view .fc-day[data-date='#{today_date}'][aria-current='date']")
       expect(page).to have_css(
-        ".fc-month-view .fc-day[data-date='#{today_date}'][aria-label='#{today_label}']"
+        ".fc-month-view .fc-bg .fc-day[data-date='#{today_date}'][aria-label='#{today_label}']"
       )
       expect(page).to have_css(selected_cell_selector, count: 1)
 
       selected_date_before_click = find(selected_cell_selector)["data-date"]
       target_date = page.evaluate_script(<<~JS)
         (() => {
-          const cells = Array.from(document.querySelectorAll(".fc-month-view .fc-day[data-date]"))
+          const cells = Array.from(document.querySelectorAll(".fc-month-view .fc-bg .fc-day[data-date]"))
             .filter(cell => cell.offsetParent !== null);
           const selectedIndex = cells.findIndex(cell => cell.getAttribute("aria-selected") === "true");
           const selectedDate = cells[selectedIndex].getAttribute("data-date");
@@ -351,25 +389,32 @@ describe "event calendar", js: true do
       )
       expect(page).to have_css(".fc-month-view .fc-day[data-date='#{target_date}'][aria-selected='true']")
       expect(page).to have_css(
-        ".fc-month-view .fc-day[data-date][tabindex='0'][aria-selected='true'].fc-gather-grid-active",
+        ".fc-month-view .fc-bg .fc-day[data-date][tabindex='0'][aria-selected='true'].fc-gather-grid-active",
         count: 1
+      )
+      target_label = page.evaluate_script(
+        "`${moment('#{target_date}', 'YYYY-MM-DD').format('dddd, MMMM D, YYYY')}, No events`"
+      )
+      expect(page).to have_css(
+        ".fc-month-view .fc-bg .fc-day[data-date='#{target_date}']" \
+        "[aria-label='#{target_label}'][tabindex='0']"
       )
       expect(page).to have_css(".fc-month-view .fc-day[data-date='#{today_date}'][aria-current='date']")
       expect(page).to have_css(".fc-month-view .fc-day[data-date][aria-selected='true']", count: 1)
 
       next_month_date = today.next_month.beginning_of_month.to_fs(:no_time)
       page.execute_script("$('#calendar').fullCalendar('next')")
-      expect(page).to have_css(".fc-month-view .fc-day[data-date='#{next_month_date}'][aria-label]")
-      expect(page).to have_css(".fc-month-view .fc-day[data-date][aria-label]", minimum: 1)
+      expect(page).to have_css(".fc-month-view .fc-bg .fc-day[data-date='#{next_month_date}'][aria-label]")
+      expect(page).to have_css(".fc-month-view .fc-bg .fc-day[data-date][aria-label]", minimum: 1)
       rerendered_cell = page.evaluate_script(<<~JS)
         (() => {
-          const cell = document.querySelector(".fc-month-view .fc-day[data-date='#{next_month_date}']");
+          const cell = document.querySelector(".fc-month-view .fc-bg .fc-day[data-date='#{next_month_date}']");
           const date = cell.getAttribute("data-date");
 
           return {
             date,
             label: cell.getAttribute("aria-label"),
-            expectedLabel: moment(date, "YYYY-MM-DD").format("dddd, MMMM D, YYYY")
+            expectedLabel: `${moment(date, "YYYY-MM-DD").format("dddd, MMMM D, YYYY")}, No events`
           };
         })()
       JS


### PR DESCRIPTION
Closes #1150 

- Added calendar live-region announcements for empty Week and Month views, including event counts when events are present.
- Added event count text to focused Day, Week, and Month date cells so screen reader users hear whether the focused date has no events, one event, or multiple events.
- Updated grid keyboard focus to target the labeled FullCalendar background date cells so arrowing between dates announces the correct date and event count.
- Count rendered event segments instead of raw FullCalendar events so Week and Month labels match the events users actually see.
- Added a guard around visible date range lookup so rendered event counts are skipped safely if FullCalendar has not provided a usable range.
- Added system spec coverage for empty announcements, event counts, and month-grid arrow navigation labels.