### PR TITLE
Add keyboard navigation and labels for Day/Week time slots (#1239)

### DIFF
--- a/app/assets/javascripts/backbone/views/calendars/calendar_view.js
+++ b/app/assets/javascripts/backbone/views/calendars/calendar_view.js
@@ -16,6 +16,7 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
     this.defaultViewType = options.defaultViewType || "week";
     this.calendar = this.$("#calendar");
     this.liveRegion = this.$("#calendar-live-region");
+    this.gridFocusLiveRegion = this.$("#calendar-grid-focus-live-region");
     this.ruleSet = options.ruleSet;
     this.canCreate = options.canCreate;
     this.calendarId = options.calendarId;
@@ -23,7 +24,13 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
     this.allDayText = options.allDayText;
     this._fcHeaderLastFocusKey = null;
     this._fcGridFocusDate = null;
+    this._fcGridFocusTime = null;
     this._fcGridShouldFocus = false;
+    this._fcGridHideSlotsTimer = null;
+    this._fcPreservedGridCell = null;
+    this._fcPreservedGridCellFinalLabel = null;
+    this._fcPreservedGridCellLiveAnnouncement = null;
+    this._fcGridFocusAnnouncementTimer = null;
     this._calendarLiveRegionText = null;
     this._renderedEventDateKeys = {};
     this._renderedEventRangesByKey = {};
@@ -41,10 +48,11 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
     return {
       "click .modal .btn-primary": "create",
       "click .early": "showHideEarly",
-      "click .fc-day[data-date]": "onGridCellClick",
-      "focusin .fc-day[data-date]": "onGridCellFocusIn",
+      "click .fc-day[data-date], .fc-gather-time-slot": "onGridCellClick",
+      "focusin .fc-day[data-date], .fc-gather-time-slot": "onGridCellFocusIn",
+      "focusout .fc-day[data-date], .fc-gather-time-slot": "onGridCellFocusOut",
       "focusin .fc-event": "onGridEventFocusIn",
-      "keydown .fc-day[data-date]": "onGridCellKeydown",
+      "keydown .fc-day[data-date], .fc-gather-time-slot": "onGridCellKeydown",
       "keydown .fc-event": "onGridEventKeydown",
 
       /*
@@ -177,7 +185,38 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
       body.html(`Create event from <b>${startTime}</b> to <b>${endTime}</b>?`);
     }
 
-    modal.modal("show");
+    this.showCreateConfirmModal(modal);
+  },
+
+  showCreateConfirmModal(modal) {
+    const returnFocusTo = document.activeElement;
+    const focusCancel = () => modal.find(".btn-default").first().focus();
+    const closeOnEscape = (e) => {
+      if ((e.which || e.keyCode) === 27) {
+        modal.modal("hide");
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    };
+
+    modal.off(".calendarCreateFocus");
+    $(document).off("keydown.calendarCreateFocus");
+    modal.on("shown.bs.modal.calendarCreateFocus", () => {
+      focusCancel();
+      setTimeout(focusCancel, 50);
+      setTimeout(focusCancel, 150);
+    });
+    modal.on("keydown.calendarCreateFocus", closeOnEscape);
+    $(document).on("keydown.calendarCreateFocus", closeOnEscape);
+    modal.on("hidden.bs.modal.calendarCreateFocus", () => {
+      modal.off(".calendarCreateFocus");
+      $(document).off("keydown.calendarCreateFocus");
+      this.calendar.fullCalendar("unselect");
+      if (returnFocusTo && document.contains(returnFocusTo)) {
+        setTimeout(() => returnFocusTo.focus(), 0);
+      }
+    });
+    modal.modal({keyboard: true, show: true});
   },
 
   onViewRender() {
@@ -254,6 +293,7 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
     if (this.isViewControlKey(key)) {
       this._fcHeaderLastFocusKey = null;
       this._fcGridFocusDate = null;
+      this._fcGridFocusTime = null;
       this._fcGridShouldFocus = true;
       setTimeout(() => this.focusGridAfterViewControlActivation(), 0);
       return;
@@ -308,7 +348,10 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
       if (!$grid.length) {
         return;
       }
-      $grid.attr("role", "grid");
+      $grid.attr({
+        role: "grid",
+        "aria-label": "Month calendar",
+      });
       $grid.find(".fc-row").attr("role", "row");
       $grid.find(".fc-day").attr("role", "gridcell");
       $grid.find(".fc-row table").attr("role", "presentation");
@@ -317,9 +360,24 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
     }
 
     if (view.name === "agendaDay" || view.name === "agendaWeek") {
+      /*
+       * One named grid for all-day + timed slots. Separate nested role="grid"
+       * regions (especially an unlabeled time grid) become empty "browse mode"
+       * stops when Tab leaves the all-day row.
+       */
+      const $agenda = this.calendar.find(".fc-agenda-view").first();
+      if ($agenda.length) {
+        $agenda.attr({
+          role: "grid",
+          "aria-label": this.agendaGridLabel(view),
+        });
+        // FullCalendar's visual divider is decorative and otherwise announced as "separator".
+        $agenda.find(".fc-divider").attr("aria-hidden", "true");
+      }
+
       const $allDayGrid = this.calendar.find(".fc-agenda-view .fc-day-grid").first();
       if ($allDayGrid.length) {
-        $allDayGrid.attr("role", "grid");
+        $allDayGrid.attr("role", "presentation");
         $allDayGrid.find(".fc-row").attr("role", "row");
         $allDayGrid.find(".fc-day").attr("role", "gridcell");
         $allDayGrid.find(".fc-row table").attr("role", "presentation");
@@ -327,33 +385,168 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
 
       const $timeGrid = this.calendar.find(".fc-time-grid").first();
       if ($timeGrid.length) {
-        $timeGrid.attr("role", "grid");
-        $timeGrid.find(".fc-slats tr").attr("role", "row");
-        $timeGrid.find(".fc-slats td").attr("role", "gridcell");
+        $timeGrid.attr("role", "presentation");
         $timeGrid.find("table").attr("role", "presentation");
+        // Slats are shared across days; use injected per-(day,time) cells instead.
+        $timeGrid.find(".fc-slats tr, .fc-slats td").removeAttr("role");
+        // Hide the visual time axis from the accessibility tree; the grid label
+        // announces the overall range, and focused slots announce a specific time.
+        $timeGrid.find(".fc-slats").attr("aria-hidden", "true");
+        this.injectAgendaTimeSlotCells();
       }
 
       this.applyFullCalendarGridKeyboard();
     }
   },
 
+  agendaGridLabel(view) {
+    const viewName = view.name === "agendaDay" ? "Day calendar" : "Week calendar";
+    const range = this.visibleTimedSlotRangeLabel();
+    if (!range) {
+      const structure = this.timedEventsOnly ? "" : " All Day row.";
+      return `${viewName}.${structure} Use arrow keys to navigate`;
+    }
+    const timedSlots = `${this.timeSlotIntervalLabel()} ${range}`;
+    const structure = this.timedEventsOnly
+      ? `Grid of ${timedSlots}`
+      : `All Day row followed by ${timedSlots}`;
+    return (
+      `${viewName}. ${structure}. ` +
+      "Use arrow keys to navigate"
+    );
+  },
+
+  visibleTimedSlotRangeLabel() {
+    const times = this.slotTimes();
+    if (!times.length) {
+      return null;
+    }
+    const start = $.fullCalendar.moment(times[0], "HH:mm:ss");
+    const end = $.fullCalendar
+      .moment(times[times.length - 1], "HH:mm:ss")
+      .add(this.slotDurationMinutes(times), "minutes");
+    return `from ${this.accessibleTimeLabel(start)} to ${this.accessibleTimeLabel(end)}`;
+  },
+
+  timeSlotIntervalLabel() {
+    const minutes = this.slotDurationMinutes(this.slotTimes());
+    return minutes === 30 ? "half-hour time slots" : `${minutes}-minute time slots`;
+  },
+
+  accessibleTimeLabel(time) {
+    return time.minutes() === 0 ? time.format("h A") : time.format("h mm A");
+  },
+
+  slotDurationMinutes(times) {
+    if (times.length < 2) {
+      return 30;
+    }
+    const first = $.fullCalendar.moment(times[0], "HH:mm:ss");
+    const second = $.fullCalendar.moment(times[1], "HH:mm:ss");
+    const minutes = second.diff(first, "minutes");
+    if (minutes <= 0) {
+      return 30;
+    }
+    return minutes;
+  },
+
+  injectAgendaTimeSlotCells() {
+    const $timeGrid = this.calendar.find(".fc-time-grid").first();
+    const $dayCols = $timeGrid.find(".fc-bg .fc-day[data-date]");
+    const $contentCols = $timeGrid.find(".fc-content-col");
+    const $slats = $timeGrid.find(".fc-slats tr[data-time]");
+
+    if (!$dayCols.length || !$contentCols.length || !$slats.length) {
+      return;
+    }
+
+    $contentCols.each((colIndex, colEl) => {
+      const $col = $(colEl);
+      const dateString = $dayCols.eq(colIndex).attr("data-date");
+      if (!dateString) {
+        return;
+      }
+
+      let $container = $col.children(".fc-gather-time-slots");
+      if (!$container.length) {
+        $container = $('<div class="fc-gather-time-slots"></div>');
+        $col.prepend($container);
+      } else {
+        $container.empty();
+      }
+
+      const date = $.fullCalendar.moment(dateString, "YYYY-MM-DD");
+      const colTop = $col.offset().top;
+
+      $slats.each((_, slatEl) => {
+        const $slat = $(slatEl);
+        const timeString = $slat.attr("data-time");
+        if (!timeString) {
+          return;
+        }
+
+        const timeMoment = $.fullCalendar.moment(timeString, "HH:mm:ss");
+        const label =
+          `${this.gridDateLabel(date, {includeWeekContext: true})}, ` +
+          this.accessibleTimeLabel(timeMoment);
+        const top = $slat.offset().top - colTop;
+        const height = $slat.outerHeight();
+
+        const $slot = $(
+          '<div class="fc-gather-time-slot" tabindex="-1" aria-hidden="true"></div>'
+        );
+        $slot.attr({
+          "data-date": dateString,
+          "data-time": timeString,
+          "aria-label": label,
+        });
+        $slot.css({
+          top: `${top}px`,
+          height: `${height}px`,
+        });
+        $container.append($slot);
+      });
+    });
+  },
+
   applyFullCalendarGridDateLabels() {
     const view = this.calendar.fullCalendar("getView");
-    this.calendar.find(".fc-bg .fc-day[data-date]:visible").each((_, cell) => {
+    const isAgenda = view && (view.name === "agendaDay" || view.name === "agendaWeek");
+
+    // Time-grid background columns are layout-only; labeling them creates empty browse targets.
+    this.calendar.find(".fc-time-grid .fc-bg .fc-day[data-date]").removeAttr("aria-label");
+
+    const $labelCells = isAgenda
+      ? this.calendar.find(".fc-day-grid .fc-bg .fc-day[data-date]:visible")
+      : this.calendar.find(".fc-month-view .fc-bg .fc-day[data-date]:visible");
+
+    $labelCells.each((_, cell) => {
       const $cell = $(cell);
       const dateString = $cell.attr("data-date");
       const date = $.fullCalendar.moment(dateString, "YYYY-MM-DD");
 
       if (date.isValid()) {
-        const showCount =
-          view && (view.name === "month" || view.name === "agendaDay" || view.name === "agendaWeek");
-        let label = date.format("dddd, MMMM D, YYYY");
-        if (showCount) {
-          label += `, ${this.eventCountLabel(this.renderedEventCountOnDay(date))}`;
+        let label = this.gridDateLabel(date, {includeWeekContext: isAgenda});
+        if (isAgenda && this.allDayText) {
+          label = `${this.allDayText}, ${label}`;
         }
+        label += `, ${this.eventCountLabel(this.renderedEventCountOnDay(date))}`;
         $cell.attr("aria-label", label);
       }
     });
+  },
+
+  gridDateLabel(date, options) {
+    const opts = options || {};
+    const today = $.fullCalendar.moment();
+    const label = date.format("dddd, MMMM D, YYYY");
+    if (date.format("YYYY-MM-DD") === today.format("YYYY-MM-DD")) {
+      return `Today, ${label}`;
+    }
+    if (opts.includeWeekContext && date.isSame(today, "week")) {
+      return `This week, ${label}`;
+    }
+    return label;
   },
 
   applyFullCalendarGridKeyboard() {
@@ -362,43 +555,83 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
       return;
     }
 
-    // Keep grid entry/exit on date cells only so Shift+Tab can leave naturally.
-    this.calendar.find(".fc-view").removeAttr("tabindex");
-    const today = $.fullCalendar.moment();
+    // Keep grid entry/exit on date/slot cells only so Shift+Tab can leave naturally.
+    this.calendar
+      .find(".fc-view, .fc-scroller, .fc-agenda-view, .fc-day-grid, .fc-time-grid")
+      .removeAttr("tabindex");
     let focusDate = this._fcGridFocusDate;
+    let focusTime = this._fcGridFocusTime;
 
-    if (!focusDate) {
-      if (this.getGridDayCell(today).length) {
-        focusDate = today.format("YYYY-MM-DD");
+    if (!this.getGridFocusTarget(focusDate, focusTime).length) {
+      if (focusDate && this.getGridFocusTarget(focusDate, null).length) {
+        focusTime = null;
+      } else if (focusDate && this.getGridFocusTarget(focusDate, this.firstSlotTime()).length) {
+        focusTime = this.firstSlotTime();
       } else {
-        focusDate = view.intervalStart.format("YYYY-MM-DD");
+        const today = $.fullCalendar.moment().format("YYYY-MM-DD");
+        if (this.getGridFocusTarget(today, null).length) {
+          focusDate = today;
+          focusTime = null;
+        } else if (this.getGridFocusTarget(today, this.firstSlotTime()).length) {
+          focusDate = today;
+          focusTime = this.firstSlotTime();
+        } else {
+          focusDate = view.intervalStart.format("YYYY-MM-DD");
+          focusTime = this.getGridFocusTarget(focusDate, null).length ? null : this.firstSlotTime();
+        }
       }
     }
 
-    this.setGridFocus(focusDate, {focus: this._fcGridShouldFocus});
+    this.setGridFocus(focusDate, {time: focusTime, focus: this._fcGridShouldFocus});
     this._fcGridShouldFocus = false;
   },
 
   onGridCellClick(e) {
-    const date = this.gridDateFromCell($(e.currentTarget));
+    const $cell = $(e.currentTarget);
+    const date = this.gridDateFromCell($cell);
     if (!date) {
       return;
     }
-    this.setGridFocus(date, {focus: false});
+    this.setGridFocus(date, {time: this.gridTimeFromCell($cell), focus: false});
   },
 
   onGridCellFocusIn(e) {
-    const date = this.gridDateFromCell($(e.currentTarget));
+    this.finalizePreservedGridCellLabel();
+    const $cell = $(e.currentTarget);
+    const date = this.gridDateFromCell($cell);
     if (!date) {
       return;
     }
-    this.setGridFocus(date, {focus: false});
+    const dateString = date.format("YYYY-MM-DD");
+    const time = this.gridTimeFromCell($cell);
+    if (
+      $cell.hasClass("fc-gather-grid-active") &&
+      this._fcGridFocusDate === dateString &&
+      (this._fcGridFocusTime || null) === (time || null)
+    ) {
+      return;
+    }
+    this.setGridFocus(date, {time, focus: false});
+  },
+
+  onGridCellFocusOut() {
+    setTimeout(() => this.finalizePreservedGridCellLabel(), 0);
   },
 
   onGridCellKeydown(e) {
     const keyCode = e.which || e.keyCode;
-    const date = this.gridDateFromCell($(e.currentTarget));
+    const $cell = $(e.currentTarget);
+    const date = this.gridDateFromCell($cell);
     if (!date) {
+      return;
+    }
+
+    const view = this.calendar.fullCalendar("getView");
+    const isAgenda = view && (view.name === "agendaDay" || view.name === "agendaWeek");
+    const time = this.gridTimeFromCell($cell);
+
+    if (isAgenda) {
+      this.onAgendaGridCellKeydown(e, date, time);
       return;
     }
 
@@ -431,12 +664,73 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
     e.preventDefault();
   },
 
+  onAgendaGridCellKeydown(e, date, time) {
+    const keyCode = e.which || e.keyCode;
+
+    if (keyCode === 13 || keyCode === 32) {
+      if (time) {
+        this.selectTimeFromGrid(date, time);
+      } else {
+        this.selectDateFromGrid(date);
+      }
+      e.preventDefault();
+      return;
+    }
+
+    let nextDate = date.clone();
+    let nextTime = time;
+
+    if (keyCode === 37) {
+      nextDate = date.clone().add(-1, "day");
+    } else if (keyCode === 39) {
+      nextDate = date.clone().add(1, "day");
+    } else if (keyCode === 36) {
+      nextDate = date.clone().startOf("week");
+    } else if (keyCode === 35) {
+      nextDate = date.clone().endOf("week").startOf("day");
+    } else if (keyCode === 33) {
+      nextDate = date.clone().add(-1, "week");
+    } else if (keyCode === 34) {
+      nextDate = date.clone().add(1, "week");
+    } else if (keyCode === 38) {
+      if (time) {
+        const prevTime = this.adjacentSlotTime(time, -1);
+        if (prevTime === undefined) {
+          return;
+        }
+        nextTime = prevTime;
+      } else {
+        nextDate = date.clone().add(-1, "week");
+      }
+    } else if (keyCode === 40) {
+      if (time) {
+        const nextSlot = this.adjacentSlotTime(time, 1);
+        if (nextSlot === undefined) {
+          return;
+        }
+        nextTime = nextSlot;
+      } else {
+        const firstTime = this.firstSlotTime();
+        if (!firstTime) {
+          nextDate = date.clone().add(1, "week");
+        } else {
+          nextTime = firstTime;
+        }
+      }
+    } else {
+      return;
+    }
+
+    this.moveGridFocus(nextDate, nextTime);
+    e.preventDefault();
+  },
+
   onGridEventFocusIn(e) {
     const date = this.resolveGridDateFromElement($(e.currentTarget));
     if (!date) {
       return;
     }
-    this.setGridFocus(date, {focus: false});
+    this.setGridFocus(date, {time: null, focus: false});
   },
 
   onGridEventKeydown(e) {
@@ -494,50 +788,220 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
     this.calendar.fullCalendar("select", start, end);
   },
 
+  selectTimeFromGrid(date, timeString) {
+    if (!this.canCreate) {
+      return;
+    }
+    const dateString = date.format("YYYY-MM-DD");
+    const start = $.fullCalendar.moment(`${dateString}T${timeString}`);
+    const end = start.clone().add(this.slotDurationMinutes(this.slotTimes()), "minutes");
+    this.calendar.fullCalendar("select", start, end);
+  },
+
   moveGridFocusToDate(date) {
+    this.moveGridFocus(date, null);
+  },
+
+  moveGridFocus(date, time) {
     const dateString = date.format("YYYY-MM-DD");
     this._fcGridFocusDate = dateString;
+    this._fcGridFocusTime = time || null;
 
-    if (this.getGridDayCell(date).length) {
-      this.setGridFocus(dateString, {focus: true});
+    if (this.getGridFocusTarget(dateString, time).length) {
+      this.setGridFocus(dateString, {time, focus: true});
       return;
     }
 
     this._fcGridShouldFocus = true;
+    this.prepareFocusedGridCellForRender(date, time);
+    this.preserveFocusedGridCellDuringRender();
     this.calendar.fullCalendar("gotoDate", date);
   },
 
+  prepareFocusedGridCellForRender(date, time) {
+    const $focused = $(document.activeElement);
+    if (time && $focused.hasClass("fc-gather-time-slot")) {
+      const timeMoment = $.fullCalendar.moment(time, "HH:mm:ss");
+      $focused.attr(
+        "aria-label",
+        `${this.gridDateLabel(date, {includeWeekContext: true})}, ` +
+          this.accessibleTimeLabel(timeMoment)
+      );
+      return $focused;
+    } else if (
+      $focused.is(".fc-day[data-date]") &&
+      $focused.closest(".fc-agenda-view .fc-day-grid").length
+    ) {
+      $focused.attr(
+        "aria-label",
+        `All Day, ${this.gridDateLabel(date, {includeWeekContext: true})}`
+      );
+      return $focused;
+    }
+    return $();
+  },
+
+  preserveFocusedGridCellDuringRender() {
+    const $focused = $(document.activeElement);
+    const isTimeSlot = $focused.hasClass("fc-gather-time-slot");
+    const isAllDayCell =
+      $focused.is(".fc-day[data-date]") &&
+      $focused.closest(".fc-agenda-view .fc-day-grid").length > 0;
+    if ((!isTimeSlot && !isAllDayCell) || !this.calendar[0].contains($focused[0])) {
+      return;
+    }
+
+    /*
+     * FullCalendar replaces the complete view when keyboard navigation crosses a week
+     * boundary. Keep the focused time slot or All Day cell connected to the document
+     * during that replacement so VoiceOver does not reset to the start of the page and
+     * re-announce every ancestor.
+     */
+    this._fcPreservedGridCell = $focused;
+    this.$el.append($focused);
+  },
+
+  restorePreservedGridCell($target) {
+    const $preserved = this._fcPreservedGridCell;
+    if (!$preserved || !$preserved.length) {
+      return $target;
+    }
+
+    const preservedIsTimeSlot = $preserved.hasClass("fc-gather-time-slot");
+    const targetIsTimeSlot = $target.hasClass("fc-gather-time-slot");
+    if (preservedIsTimeSlot !== targetIsTimeSlot) {
+      return $target;
+    }
+
+    Array.from($preserved[0].attributes).forEach((attribute) => {
+      if (!$target[0].hasAttribute(attribute.name)) {
+        $preserved.removeAttr(attribute.name);
+      }
+    });
+    Array.from($target[0].attributes).forEach((attribute) => {
+      if (attribute.name !== "aria-label") {
+        $preserved.attr(attribute.name, attribute.value);
+      }
+    });
+    $preserved.removeAttr("aria-hidden");
+    this._fcPreservedGridCellFinalLabel = {
+      element: $preserved,
+      label: $target.attr("aria-label"),
+    };
+    this._fcPreservedGridCellLiveAnnouncement = $preserved.attr("aria-label");
+    $target.replaceWith($preserved);
+    this._fcPreservedGridCell = null;
+    return $preserved;
+  },
+
   setGridFocus(date, options) {
+    const opts = options || {};
     const dateString = typeof date === "string" ? date : date.format("YYYY-MM-DD");
-    const $cells = this.getNavigableGridCells();
-    const $target = this.getGridDayCell(dateString);
+    const time = Object.prototype.hasOwnProperty.call(opts, "time")
+      ? opts.time
+      : this._fcGridFocusTime;
+    let $target = this.getGridFocusTarget(dateString, time);
     if (!$target.length) {
       return false;
     }
+    $target = this.restorePreservedGridCell($target);
+    const $cells = this.getNavigableGridCells();
 
     $cells.attr("tabindex", "-1");
     $cells.removeClass("fc-gather-grid-active");
     $target.attr("tabindex", "0");
     $target.addClass("fc-gather-grid-active");
-    this.updateGridCellAriaStates(dateString);
-    if (options && options.focus) {
+    if ($target.hasClass("fc-gather-time-slot")) {
+      $target.attr({
+        role: "button",
+      });
+      $target.removeAttr("aria-hidden");
+    }
+    this.updateGridCellAriaStates(dateString, time);
+    this._fcGridFocusDate = dateString;
+    this._fcGridFocusTime = time || null;
+    if (opts.focus && document.activeElement !== $target[0]) {
       $target.focus();
     }
-    this._fcGridFocusDate = dateString;
+    this.announcePreservedGridCell();
+
+    /*
+     * Give screen readers time to process the new focus before removing the prior slot
+     * from the accessibility tree. A synchronous removal makes VoiceOver fall back to an
+     * unrelated event link elsewhere in the calendar.
+     */
+    clearTimeout(this._fcGridHideSlotsTimer);
+    this._fcGridHideSlotsTimer = setTimeout(() => this.hideInactiveTimeSlots(), 250);
+
     return true;
   },
 
-  updateGridCellAriaStates(selectedDateString) {
+  announcePreservedGridCell() {
+    const message = this._fcPreservedGridCellLiveAnnouncement;
+    this._fcPreservedGridCellLiveAnnouncement = null;
+    if (!message || !this.gridFocusLiveRegion.length) {
+      return;
+    }
+
+    clearTimeout(this._fcGridFocusAnnouncementTimer);
+    this.gridFocusLiveRegion.text("");
+    this._fcGridFocusAnnouncementTimer = setTimeout(() => {
+      this.gridFocusLiveRegion.text(message);
+    }, 50);
+  },
+
+  finalizePreservedGridCellLabel() {
+    const finalLabel = this._fcPreservedGridCellFinalLabel;
+    if (!finalLabel || !finalLabel.label || document.activeElement === finalLabel.element[0]) {
+      return;
+    }
+
+    finalLabel.element.attr("aria-label", finalLabel.label);
+    this._fcPreservedGridCellFinalLabel = null;
+  },
+
+  hideInactiveTimeSlots() {
+    this.calendar
+      .find(".fc-gather-time-slot")
+      .not(".fc-gather-grid-active")
+      .each((_, el) => {
+        const $slot = $(el);
+        $slot.attr({
+          "aria-hidden": "true",
+          tabindex: "-1",
+        });
+        $slot.removeAttr("role");
+        $slot.removeAttr("aria-selected");
+      });
+  },
+
+  updateGridCellAriaStates(selectedDateString, selectedTime) {
     const todayString = $.fullCalendar.moment().format("YYYY-MM-DD");
     const $cells = this.getNavigableGridCells();
+    const focusTime = selectedTime || null;
 
     $cells.each((_, cell) => {
       const $cell = $(cell);
       const dateString = $cell.attr("data-date");
-      const isSelected = dateString === selectedDateString;
-      const isToday = dateString === todayString;
+      const cellTime = this.gridTimeFromCell($cell);
+      const isSelected =
+        dateString === selectedDateString &&
+        (cellTime || null) === focusTime;
+      const isDayCell = !$cell.hasClass("fc-gather-time-slot");
+      const isToday = isDayCell && dateString === todayString;
 
-      $cell.attr("aria-selected", isSelected ? "true" : "false");
+      if (!isDayCell) {
+        $cell.removeAttr("aria-selected");
+        $cell.removeAttr("aria-current");
+        return;
+      }
+
+      // Only expose aria-selected when true; "false" is announced as "not selected".
+      if (isSelected) {
+        $cell.attr("aria-selected", "true");
+      } else {
+        $cell.removeAttr("aria-selected");
+      }
       if (isToday) {
         $cell.attr("aria-current", "date");
       } else {
@@ -547,13 +1011,26 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
   },
 
   getGridDayCell(date) {
+    return this.getGridFocusTarget(date, null);
+  },
+
+  getGridFocusTarget(date, time) {
+    if (!date) {
+      return $();
+    }
     const dateString = typeof date === "string" ? date : date.format("YYYY-MM-DD");
-    return this.getNavigableGridCells()
+    if (time) {
+      return this.calendar
+        .find(`.fc-gather-time-slot[data-date="${dateString}"][data-time="${time}"]`)
+        .first();
+    }
+
+    return this.getNavigableDayCells()
       .filter((_, el) => $(el).attr("data-date") === dateString)
       .first();
   },
 
-  getNavigableGridCells() {
+  getNavigableDayCells() {
     const view = this.calendar.fullCalendar("getView");
     if (!view) {
       return this.calendar.find(".fc-day[data-date]");
@@ -563,20 +1040,92 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
       return this.calendar.find(".fc-month-view .fc-bg .fc-day[data-date]:visible");
     }
 
-    const $allDayCells = this.calendar.find(".fc-agenda-view .fc-day-grid .fc-bg .fc-day[data-date]:visible");
+    const $allDayCells = this.calendar.find(
+      ".fc-agenda-view .fc-day-grid .fc-bg .fc-day[data-date]:visible"
+    );
     if ($allDayCells.length) {
       return $allDayCells;
+    }
+
+    return $();
+  },
+
+  getNavigableGridCells() {
+    const view = this.calendar.fullCalendar("getView");
+    if (!view) {
+      return this.calendar.find(".fc-day[data-date], .fc-gather-time-slot");
+    }
+
+    if (view.name === "month") {
+      return this.getNavigableDayCells();
+    }
+
+    const $dayCells = this.getNavigableDayCells();
+    const $slots = this.calendar.find(".fc-gather-time-slot");
+    if ($dayCells.length && $slots.length) {
+      return $dayCells.add($slots);
+    }
+    if ($slots.length) {
+      return $slots;
+    }
+    if ($dayCells.length) {
+      return $dayCells;
     }
 
     return this.calendar.find(".fc-time-grid .fc-bg .fc-day[data-date]:visible");
   },
 
   gridDateFromCell($cell) {
-    const dateString = $cell.data("date") || $cell.attr("data-date");
+    const dateString = $cell.attr("data-date") || $cell.data("date");
     if (!dateString) {
       return null;
     }
     return $.fullCalendar.moment(dateString, "YYYY-MM-DD");
+  },
+
+  gridTimeFromCell($cell) {
+    if (!$cell.hasClass("fc-gather-time-slot")) {
+      return null;
+    }
+    return $cell.attr("data-time") || null;
+  },
+
+  slotTimes() {
+    return this.calendar
+      .find(".fc-slats tr[data-time]")
+      .map((_, el) => $(el).attr("data-time"))
+      .get();
+  },
+
+  firstSlotTime() {
+    const times = this.slotTimes();
+    return times.length ? times[0] : null;
+  },
+
+  /*
+   * Returns the adjacent slot time string, null for all-day (when moving up from the first
+   * slot and an all-day row exists), or undefined when there is no valid move.
+   */
+  adjacentSlotTime(time, delta) {
+    const times = this.slotTimes();
+    const index = times.indexOf(time);
+    if (index < 0) {
+      return undefined;
+    }
+
+    const nextIndex = index + delta;
+    if (nextIndex >= 0 && nextIndex < times.length) {
+      return times[nextIndex];
+    }
+
+    if (nextIndex < 0) {
+      if (this.getNavigableDayCells().length) {
+        return null;
+      }
+      return undefined;
+    }
+
+    return undefined;
   },
 
   resolveGridDateFromElement($element) {
@@ -807,8 +1356,10 @@ Gather.Views.Calendars.CalendarView = Backbone.View.extend({
     this.viewParams.earlyMorning = !this.viewParams.earlyMorning;
     this.showAppropriateEarlyLink();
     this.calendar.fullCalendar("option", "minTime", this.minTime());
-    // Explicitly notify the link manager; minTime changes don't always re-fire
-    // eventAfterAllRender since FullCalendar may skip the event rendering pipeline.
+    // Explicitly rebuild a11y slots and notify the link manager; minTime changes don't
+    // always re-fire eventAfterAllRender since FullCalendar may skip that pipeline.
+    this.applyFullCalendarGridA11y();
+    setTimeout(() => this.applyFullCalendarGridA11y(), 0);
     this.$el.trigger("viewRender");
   },
 

--- a/app/assets/stylesheets/global/fullcalendar_overrides.scss
+++ b/app/assets/stylesheets/global/fullcalendar_overrides.scss
@@ -30,13 +30,36 @@
     min-height: 90px;
   }
 
-  .fc-day.fc-gather-grid-active {
+  .fc-day.fc-gather-grid-active,
+  .fc-gather-time-slot.fc-gather-grid-active {
     box-shadow: inset 0 0 0 2px rgba(0, 0, 0, 0.15);
   }
 
-  .fc-day[tabindex="0"]:focus {
+  .fc-day[tabindex="0"]:focus,
+  .fc-gather-time-slot[tabindex="0"]:focus {
     outline: 3px solid $theme-main;
     outline-offset: -3px;
     box-shadow: inset 0 0 0 2px #fff;
+  }
+
+  .fc-content-col {
+    position: relative;
+  }
+
+  .fc-gather-time-slots {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  .fc-gather-time-slot {
+    position: absolute;
+    left: 0;
+    right: 0;
+    pointer-events: none;
   }
 }

--- a/app/views/calendars/events/index.html.erb
+++ b/app/views/calendars/events/index.html.erb
@@ -20,21 +20,24 @@
 <div id="calendar-and-sidebar">
   <div id="calendar-col">
     <div id="calendar-live-region" class="sr-only" aria-live="polite" aria-atomic="true"></div>
+    <div id="calendar-grid-focus-live-region" class="sr-only" aria-live="assertive" aria-atomic="true"></div>
     <div id="calendar"></div>
     <footer>
       <%= link_to("Permalink", @permalink, id: "permalink") %> &nbsp;
       <a href="#" class="early" id="show-early">Show Early Morning</a>
       <a href="#" class="early" id="hide-early">Hide Early Morning</a>
     </footer>
-    <div id="create-confirm-modal" class="modal fade">
+    <div id="create-confirm-modal" class="modal fade" tabindex="-1" role="dialog"
+         aria-modal="true" aria-labelledby="create-confirm-modal-title"
+         aria-describedby="create-confirm-modal-body">
       <div class="modal-dialog">
         <div class="modal-content">
           <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-label="Close">
               <span aria-hidden="true">&times;</span></button>
-            <h2 class="modal-title">Create Event?</h2>
+            <h2 class="modal-title" id="create-confirm-modal-title">Create Event?</h2>
           </div>
-          <div class="modal-body">
+          <div class="modal-body" id="create-confirm-modal-body">
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>

--- a/spec/system/calendars/events/index_spec.rb
+++ b/spec/system/calendars/events/index_spec.rb
@@ -332,21 +332,273 @@ describe "event calendar", js: true do
 
       visit(calendar_events_path(calendar))
 
-      today_label = page.evaluate_script(
-        "`${moment('#{today.to_fs(:no_time)}', 'YYYY-MM-DD').format('dddd, MMMM D, YYYY')}, 1 event`"
-      )
+      week_today_label = expected_date_label(today, prefix: "All Day", count: "1 event")
+      month_today_label = expected_date_label(today, count: "1 event")
 
       expect(page).to have_css("#calendar-live-region", text: "1 event this week", visible: false)
       expect(page).to have_css(
         ".fc-agendaWeek-view .fc-day-grid .fc-bg .fc-day[data-date='#{today.to_fs(:no_time)}']" \
-        "[aria-label='#{today_label}']"
+        "[aria-label='#{week_today_label}']"
       )
 
       find(".fc-month-button").click
       expect(page).to have_css("#calendar-live-region", text: "1 event this month", visible: false)
       expect(page).to have_css(
-        ".fc-month-view .fc-bg .fc-day[data-date='#{today.to_fs(:no_time)}'][aria-label='#{today_label}']"
+        ".fc-month-view .fc-bg .fc-day[data-date='#{today.to_fs(:no_time)}']" \
+        "[aria-label='#{month_today_label}']"
       )
+    end
+
+    scenario "supports keyboard navigation and labels for day and week time slots" do
+      visit(calendar_events_path(calendar))
+
+      today = Time.zone.today
+      today_date = today.to_fs(:no_time)
+      current_week_other_day = today.wday.zero? ? today + 1.day : today - 1.day
+      current_week_other_date = current_week_other_day.to_fs(:no_time)
+      all_day_selector =
+        ".fc-agendaWeek-view .fc-day-grid .fc-bg .fc-day[data-date='#{today_date}']"
+      current_week_all_day_selector =
+        ".fc-agendaWeek-view .fc-day-grid .fc-bg .fc-day[data-date='#{current_week_other_date}']"
+      first_slot_selector =
+        ".fc-agendaWeek-view .fc-gather-time-slot[data-date='#{today_date}'][data-time='06:00:00']"
+      current_week_slot_selector =
+        ".fc-agendaWeek-view .fc-gather-time-slot" \
+        "[data-date='#{current_week_other_date}'][data-time='06:00:00']"
+
+      all_day_label = expected_date_label(today, prefix: "All Day", include_week_context: true)
+      current_week_all_day_label =
+        expected_date_label(current_week_other_day, prefix: "All Day", include_week_context: true)
+      first_slot_label = expected_time_slot_label(today, "06:00:00", include_week_context: true)
+      current_week_slot_label =
+        expected_time_slot_label(current_week_other_day, "06:00:00", include_week_context: true)
+
+      expect(page).to have_css("#{all_day_selector}[aria-label='#{all_day_label}']")
+      expect(page).to have_css("#{current_week_all_day_selector}[aria-label='#{current_week_all_day_label}']")
+      expect(page).to have_css("#{first_slot_selector}[aria-label='#{first_slot_label}']")
+      expect(page).to have_css("#{current_week_slot_selector}[aria-label='#{current_week_slot_label}']")
+      week_grid_label = expected_grid_label(".fc-agendaWeek-view", "Week calendar")
+      expect(page).to have_css(
+        ".fc-agendaWeek-view[role='grid'][aria-label='#{week_grid_label}']"
+      )
+      expect(page).to have_no_css(".fc-agendaWeek-view .fc-time-grid[role='grid']")
+      expect(page).to have_no_css(".fc-agendaWeek-view .fc-time-grid .fc-bg .fc-day[aria-label]")
+      expect(page).to have_css("#{first_slot_selector}[aria-hidden='true']")
+      expect(page).to have_css(".fc-agendaWeek-view .fc-slats[aria-hidden='true']")
+
+      find("#{all_day_selector}[tabindex='0']").send_keys(:tab)
+      tab_target = page.evaluate_script(<<~JS)
+        (() => {
+          const el = document.activeElement;
+          if (!el || el === document.body) {
+            return {ok: true, reason: "body"};
+          }
+          const role = el.getAttribute("role");
+          const label = el.getAttribute("aria-label") || el.getAttribute("aria-labelledby");
+          const inUnlabeledGrid = role === "grid" && !label;
+          const isTimeGridChrome = !!(el.closest && el.closest(".fc-time-grid") &&
+            !el.classList.contains("fc-gather-time-slot") && !el.classList.contains("fc-event"));
+          return {
+            ok: !inUnlabeledGrid && !isTimeGridChrome,
+            role,
+            label,
+            className: el.className,
+            id: el.id
+          };
+        })()
+      JS
+      expect(tab_target["ok"]).to eq(true),
+        "Tab from all-day landed on unlabeled calendar chrome: #{tab_target.inspect}"
+
+      find("#{all_day_selector}[tabindex='0']").send_keys(:arrow_down)
+      expect_active_gridcell("#{first_slot_selector}[tabindex='0']")
+      expect(page).to have_css(
+        "#{first_slot_selector}[role='button']:not([aria-hidden='true'])"
+      )
+      expect(page).to have_no_css("#{first_slot_selector}[aria-selected]")
+      expect(page).to have_no_css("#{first_slot_selector}[aria-describedby]")
+      expect(page).to have_css(
+        ".fc-agendaWeek-view .fc-gather-time-slot[data-time='06:30:00'][aria-hidden='true']",
+        minimum: 1
+      )
+      expect(page).to have_no_css(
+        ".fc-agendaWeek-view .fc-gather-time-slot[aria-selected='false']"
+      )
+
+      find(first_slot_selector).send_keys(:arrow_down)
+      half_hour_selector =
+        ".fc-agendaWeek-view .fc-gather-time-slot[data-date='#{today_date}']" \
+        "[data-time='06:30:00']"
+      expect_active_gridcell("#{half_hour_selector}[tabindex='0']")
+      half_hour_label = expected_time_slot_label(today, "06:30:00", include_week_context: true)
+      expect(page).to have_css("#{half_hour_selector}[aria-label='#{half_hour_label}']")
+
+      find(half_hour_selector).send_keys(:arrow_up)
+      expect_active_gridcell(
+        "#{first_slot_selector}[role='button'][tabindex='0']:not([aria-hidden='true'])"
+      )
+      expect(page).to have_css("#{half_hour_selector}[aria-hidden='true']:not([role])")
+
+      find(first_slot_selector).send_keys(:arrow_up)
+      expect_active_gridcell("#{all_day_selector}[tabindex='0']")
+
+      find("#{all_day_selector}[tabindex='0']").send_keys(:arrow_down)
+      move = page.evaluate_script(<<~JS)
+        (() => {
+          const current = document.querySelector(#{first_slot_selector.to_json});
+          const currentDate = current.getAttribute("data-date");
+          const slots = Array.from(
+            document.querySelectorAll(
+              ".fc-agendaWeek-view .fc-gather-time-slot[data-time='06:00:00']"
+            )
+          );
+          const next = slots.find((slot) => slot.getAttribute("data-date") > currentDate);
+          if (next) {
+            return {date: next.getAttribute("data-date"), key: "ArrowRight"};
+          }
+          const prev = [...slots].reverse()
+            .find((slot) => slot.getAttribute("data-date") < currentDate);
+          return prev && {date: prev.getAttribute("data-date"), key: "ArrowLeft"};
+        })()
+      JS
+      expect(move).to be_present
+      find(first_slot_selector).send_keys(move["key"] == "ArrowRight" ? :arrow_right : :arrow_left)
+      adjacent_slot_selector =
+        ".fc-agendaWeek-view .fc-gather-time-slot[data-date='#{move['date']}']" \
+        "[data-time='06:00:00']"
+      expect_active_gridcell("#{adjacent_slot_selector}[tabindex='0']")
+
+      find(adjacent_slot_selector).send_keys(:enter)
+      expect(page).to have_content(/Create event on.+6:00 am to 6:30 am/i)
+      expect(page).to have_css(
+        "#create-confirm-modal[role='dialog'][aria-modal='true']" \
+        "[aria-labelledby='create-confirm-modal-title']"
+      )
+      expect(page).to have_css("#create-confirm-modal-title", text: "Create Event?")
+      expect(page).to have_css("#create-confirm-modal .btn-default:focus", text: "Cancel")
+      expect(page).to have_css(".fc-helper-container .fc-event")
+
+      find("#create-confirm-modal .btn-default").send_keys(:escape)
+      expect(page).to have_no_css(".modal.in")
+      expect(page).to have_no_css(".fc-helper-container .fc-event")
+      expect_active_gridcell("#{adjacent_slot_selector}[tabindex='0']")
+      find(".fc-today-button").click
+      find(".fc-agendaDay-button").click
+      expect(page).to have_css(".fc-agendaDay-view .fc-time-grid")
+
+      day_all_day_selector =
+        ".fc-agendaDay-view .fc-day-grid .fc-bg .fc-day[data-date='#{today_date}']"
+      day_first_slot_selector =
+        ".fc-agendaDay-view .fc-gather-time-slot[data-date='#{today_date}'][data-time='06:00:00']"
+      day_all_day_label = expected_date_label(today, prefix: "All Day", include_week_context: true)
+      day_first_slot_label = expected_time_slot_label(today, "06:00:00", include_week_context: true)
+
+      expect(page).to have_css("#{day_all_day_selector}[aria-label='#{day_all_day_label}']")
+      expect(page).to have_css("#{day_first_slot_selector}[aria-label='#{day_first_slot_label}']")
+      day_grid_label = expected_grid_label(".fc-agendaDay-view", "Day calendar")
+      expect(page).to have_css(".fc-agendaDay-view[role='grid'][aria-label='#{day_grid_label}']")
+
+      find(day_all_day_selector).send_keys(:arrow_down)
+      expect_active_gridcell("#{day_first_slot_selector}[tabindex='0']")
+
+      find("#show-early").click
+      midnight_slot_selector =
+        ".fc-agendaDay-view .fc-gather-time-slot[data-date='#{today_date}'][data-time='00:00:00']"
+      expect(page).to have_css(".fc-agendaDay-view .fc-divider[aria-hidden='true']", visible: false)
+      page.execute_script("document.querySelector(#{midnight_slot_selector.to_json}).focus()")
+      expect_active_gridcell("#{midnight_slot_selector}[role='button'][tabindex='0']")
+      expect(page).to have_no_css("#{midnight_slot_selector}[aria-selected]")
+      find(midnight_slot_selector).send_keys(:arrow_up)
+      expect_active_gridcell("#{day_all_day_selector}[tabindex='0']")
+    end
+
+    scenario "preserves the focused time slot when arrow navigation crosses weeks" do
+      visit(calendar_events_path(calendar))
+
+      last_date = all(".fc-agendaWeek-view .fc-gather-time-slot[data-time='06:00:00']")
+        .last["data-date"]
+      first_new_week_date = Date.iso8601(last_date).next_day
+      second_new_week_date = first_new_week_date.next_day
+      last_slot_selector =
+        ".fc-agendaWeek-view .fc-gather-time-slot[data-date='#{last_date}'][data-time='06:00:00']"
+      first_new_week_slot_selector =
+        ".fc-agendaWeek-view .fc-gather-time-slot" \
+        "[data-date='#{first_new_week_date.to_fs(:no_time)}'][data-time='06:00:00']"
+      second_new_week_slot_selector =
+        ".fc-agendaWeek-view .fc-gather-time-slot" \
+        "[data-date='#{second_new_week_date.to_fs(:no_time)}'][data-time='06:00:00']"
+
+      page.execute_script(<<~JS)
+        window.calendarFocusedSlot = document.querySelector(#{last_slot_selector.to_json});
+        window.calendarFocusedSlot.focus();
+      JS
+      find(last_slot_selector).send_keys(:arrow_right)
+
+      expect_active_gridcell("#{first_new_week_slot_selector}[tabindex='0']")
+      first_new_week_label =
+        expected_time_slot_label(first_new_week_date, "06:00:00", include_week_context: true)
+      expect(page).to have_css(
+        "#{first_new_week_slot_selector}[aria-label='#{first_new_week_label}']"
+      )
+      expect(page).to have_css(
+        "#calendar-grid-focus-live-region[aria-live='assertive'][aria-atomic='true']",
+        text: first_new_week_label,
+        visible: false
+      )
+      expect(page.evaluate_script(
+        "window.calendarFocusedSlot === document.activeElement"
+      )).to eq(true)
+
+      find(first_new_week_slot_selector).send_keys(:arrow_right)
+      expect_active_gridcell("#{second_new_week_slot_selector}[tabindex='0']")
+    end
+
+    scenario "preserves the focused all-day cell when arrow navigation crosses weeks" do
+      visit(calendar_events_path(calendar))
+
+      all_day_cells = all(
+        ".fc-agendaWeek-view .fc-day-grid .fc-bg .fc-day[data-date]"
+      )
+      last_date = all_day_cells.last["data-date"]
+      first_new_week_date = Date.iso8601(last_date).next_day
+      second_new_week_date = first_new_week_date.next_day
+      last_cell_selector =
+        ".fc-agendaWeek-view .fc-day-grid .fc-bg .fc-day[data-date='#{last_date}']"
+      first_new_week_cell_selector =
+        ".fc-agendaWeek-view .fc-day-grid .fc-bg .fc-day" \
+        "[data-date='#{first_new_week_date.to_fs(:no_time)}']"
+      second_new_week_cell_selector =
+        ".fc-agendaWeek-view .fc-day-grid .fc-bg .fc-day" \
+        "[data-date='#{second_new_week_date.to_fs(:no_time)}']"
+
+      page.execute_script(<<~JS)
+        window.calendarFocusedAllDayCell = document.querySelector(#{last_cell_selector.to_json});
+        window.calendarFocusedAllDayCell.focus();
+      JS
+      find(last_cell_selector).send_keys(:arrow_right)
+
+      expect_active_gridcell("#{first_new_week_cell_selector}[tabindex='0']")
+      first_new_week_label =
+        expected_date_label(
+          first_new_week_date,
+          prefix: "All Day",
+          count: nil,
+          include_week_context: true
+        )
+      expect(page).to have_css(
+        "#{first_new_week_cell_selector}[aria-label='#{first_new_week_label}']"
+      )
+      expect(page).to have_css(
+        "#calendar-grid-focus-live-region[aria-live='assertive'][aria-atomic='true']",
+        text: first_new_week_label,
+        visible: false
+      )
+      expect(page.evaluate_script(
+        "window.calendarFocusedAllDayCell === document.activeElement"
+      )).to eq(true)
+
+      find(first_new_week_cell_selector).send_keys(:arrow_right)
+      expect_active_gridcell("#{second_new_week_cell_selector}[tabindex='0']")
     end
 
     scenario "exposes selected, active, and today states on date cells" do
@@ -355,9 +607,7 @@ describe "event calendar", js: true do
 
       today = Time.zone.today
       today_date = today.to_fs(:no_time)
-      today_label = page.evaluate_script(
-        "`${moment('#{today_date}', 'YYYY-MM-DD').format('dddd, MMMM D, YYYY')}, No events`"
-      )
+      today_label = expected_date_label(today)
       selected_cell_selector =
         ".fc-month-view .fc-bg .fc-day[data-date][tabindex='0'][aria-selected='true']"
 
@@ -408,7 +658,8 @@ describe "event calendar", js: true do
       expect(page).to have_css(".fc-month-view .fc-bg .fc-day[data-date][aria-label]", minimum: 1)
       rerendered_cell = page.evaluate_script(<<~JS)
         (() => {
-          const cell = document.querySelector(".fc-month-view .fc-bg .fc-day[data-date='#{next_month_date}']");
+          const selector = ".fc-month-view .fc-bg .fc-day[data-date='#{next_month_date}']";
+          const cell = document.querySelector(selector);
           const date = cell.getAttribute("data-date");
 
           return {
@@ -420,6 +671,66 @@ describe "event calendar", js: true do
       JS
       expect(rerendered_cell["label"]).to eq(rerendered_cell["expectedLabel"])
     end
+  end
+
+  def expected_date_label(date, prefix: nil, count: "No events", include_week_context: false)
+    date_label = page.evaluate_script(
+      "moment('#{date.to_fs(:no_time)}', 'YYYY-MM-DD').format('dddd, MMMM D, YYYY')"
+    )
+    if date == Time.zone.today
+      date_label = "Today, #{date_label}"
+    elsif include_week_context && current_week?(date)
+      date_label = "This week, #{date_label}"
+    end
+    [prefix, date_label, count].compact.join(", ")
+  end
+
+  def expected_time_slot_label(date, time, include_week_context: false)
+    date_label = page.evaluate_script(
+      "moment('#{date.to_fs(:no_time)}', 'YYYY-MM-DD').format('dddd, MMMM D, YYYY')"
+    )
+    if date == Time.zone.today
+      date_label = "Today, #{date_label}"
+    elsif include_week_context && current_week?(date)
+      date_label = "This week, #{date_label}"
+    end
+    time_label = page.evaluate_script(<<~JS)
+      (() => {
+        const time = moment(#{time.to_json}, "HH:mm:ss");
+        return time.minutes() === 0 ? time.format("h A") : time.format("h mm A");
+      })()
+    JS
+    "#{date_label}, #{time_label}"
+  end
+
+  def expected_grid_label(view_selector, view_name)
+    page.evaluate_script(<<~JS)
+      (() => {
+        const viewSelector = #{view_selector.to_json};
+        const viewName = #{view_name.to_json};
+        const times = Array.from(
+          document.querySelectorAll(`${viewSelector} .fc-slats tr[data-time]`)
+        ).map((row) => row.getAttribute("data-time"));
+        const start = moment(times[0], "HH:mm:ss");
+        const end = moment(times[times.length - 1], "HH:mm:ss");
+        const slotMinutes = times.length > 1
+          ? moment(times[1], "HH:mm:ss").diff(start, "minutes")
+          : 30;
+        end.add(slotMinutes > 0 ? slotMinutes : 30, "minutes");
+        const label = (time) => time.minutes() === 0
+          ? time.format("h A")
+          : time.format("h mm A");
+        const interval = slotMinutes === 30
+          ? "half-hour time slots"
+          : `${slotMinutes}-minute time slots`;
+        return `${viewName}. All Day row followed by ${interval} from ${label(start)} ` +
+          `to ${label(end)}. Use arrow keys to navigate`;
+      })()
+    JS
+  end
+
+  def current_week?(date)
+    date.beginning_of_week(:sunday) == Time.zone.today.beginning_of_week(:sunday)
   end
 
   def expect_selected(cal1:, cal2:)
@@ -436,8 +747,7 @@ describe "event calendar", js: true do
   end
 
   def expect_active_gridcell(selector)
-    expect(page).to have_css(selector)
-    expect(page.evaluate_script("document.activeElement.matches(#{selector.to_json})")).to be(true)
+    expect(page).to have_css("#{selector}:focus")
   end
 
   def expect_sidebar_calendar_list_landmark


### PR DESCRIPTION
## Summary
- Make Day and Week calendar time slots keyboard-navigable with clear screen reader labels (including All Day, Today/This week context, and simplified times).
- Preserve focus across week boundaries, announce landing cells without re-reading the whole page, and orient users to the All Day row plus timed grid.
- Improve create-event confirmation modal focus/Escape handling and clear temporary selections on cancel.

## Issue
Closes #1239

## Testing
- Ran `bundle exec rspec spec/system/calendars/events/index_spec.rb` (25 examples, 0 failures) with `SELENIUM_REMOTE_URL=http://localhost:4444`.
- Verified Day/Week keyboard navigation, labels, create modal focus/Escape, early-morning slots, and cross-week focus preservation in system specs.
- Manual VoiceOver checks during development: All Day and timed slot announcements, week-boundary navigation, modal cancel/unselect, and Month arrow navigation.
- Not fully retested after final push: complete VoiceOver checklist from the commit message on a fresh page load.